### PR TITLE
Fix: Date rendering crash, Resend build error, Sentry middleware 500

### DIFF
--- a/app/(app)/cases/[caseId]/CaseTabs.tsx
+++ b/app/(app)/cases/[caseId]/CaseTabs.tsx
@@ -188,7 +188,7 @@ function TimelineEntry({ entry, caseId, onDelete }: { entry: Row; caseId: string
   return (
     <div className="flex gap-3 px-4 py-3 group">
       <span className="text-xs tabular-nums w-24 flex-shrink-0 pt-0.5" style={{ color: "var(--vera-subtle)" }}>
-        {entry.date as string}
+        {fmtDate(entry.date)}
       </span>
       <span className="h-2 w-2 rounded-full flex-shrink-0 mt-1.5" style={{ background: "var(--vera-accent)" }} />
       <div className="flex-1 min-w-0 space-y-1.5">
@@ -641,7 +641,7 @@ function DeadlinesTab({ deadlines, caseId }: { deadlines: Row[]; caseId: string 
                     <div className="w-1 self-stretch rounded-full flex-shrink-0" style={{ background: style.bar }} />
                     <div className="flex-1 min-w-0">
                       <p className="text-sm font-medium" style={{ color: "var(--vera-text)" }}>{d.label as string}</p>
-                      <p className="text-xs mt-0.5" style={{ color: "var(--vera-subtle)" }}>{d.date as string}</p>
+                      <p className="text-xs mt-0.5" style={{ color: "var(--vera-subtle)" }}>{fmtDate(d.date)}</p>
                     </div>
                     <span className="text-xs font-bold px-2 py-0.5 rounded-full tabular-nums flex-shrink-0"
                       style={{ background: style.badge.bg, color: style.badge.color }}>
@@ -663,7 +663,7 @@ function DeadlinesTab({ deadlines, caseId }: { deadlines: Row[]; caseId: string 
                   <div key={i} className="flex items-center gap-3 px-4 py-2.5 group">
                     <span className="text-green-500 text-xs">✓</span>
                     <p className="text-sm line-through flex-1" style={{ color: "var(--vera-muted)" }}>{d.label as string}</p>
-                    <p className="text-xs" style={{ color: "var(--vera-subtle)" }}>{d.date as string}</p>
+                    <p className="text-xs" style={{ color: "var(--vera-subtle)" }}>{fmtDate(d.date)}</p>
                     <button onClick={() => deleteDeadline(d.id as string)}
                       className="text-[11px] sm:opacity-0 sm:group-hover:opacity-100 transition-opacity hover:text-red-500 flex-shrink-0 min-h-[36px] px-1"
                       style={{ color: "var(--vera-subtle)" }}>✕</button>

--- a/app/api/cron/deadlines/route.ts
+++ b/app/api/cron/deadlines/route.ts
@@ -61,7 +61,7 @@ import sql from "@/lib/db";
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
 
-const resend = new Resend(process.env.RESEND_API_KEY);
+// Instantiated per-request to avoid build-time errors when env var is absent
 
 function deadlineEmailHtml(caseName: string, deadlines: Array<{ label: string; date: string; days: number }>) {
   const rows = deadlines.map(d => `
@@ -129,10 +129,12 @@ export async function GET(req: Request) {
     grouped.get(key)!.items.push({ label: r.label as string, date: r.date as string, days });
   }
 
+  const resend = process.env.RESEND_API_KEY ? new Resend(process.env.RESEND_API_KEY) : null;
   let sent = 0;
   for (const { email, caseName, items } of grouped.values()) {
+    if (!resend) continue;
     await resend.emails.send({
-      from:    "Vera <reminders@vera-opal-zeta.vercel.app>",
+      from:    "Vera <support@veracase.app>",
       to:      email,
       subject: `Deadline reminder — ${items[0].days <= 1 ? "urgent" : "upcoming"}: ${caseName}`,
       html:    deadlineEmailHtml(caseName, items),

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,7 +1,5 @@
 import { Resend } from "resend";
 
-const resend = new Resend(process.env.RESEND_API_KEY);
-
 const FROM = "Vera <support@veracase.app>";
 
 /** Skip test / placeholder accounts */
@@ -15,6 +13,8 @@ export async function sendEmail(
   html: string
 ): Promise<void> {
   if (isTestEmail(to)) return;
+  if (!process.env.RESEND_API_KEY) return;
+  const resend = new Resend(process.env.RESEND_API_KEY);
   try {
     await resend.emails.send({ from: FROM, to, subject, html });
   } catch (err) {

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,14 +1,7 @@
 import type { NextConfig } from "next";
-import { withSentryConfig } from "@sentry/nextjs";
 
 const nextConfig: NextConfig = {
   /* config options here */
 };
 
-export default withSentryConfig(nextConfig, {
-  silent: !process.env.SENTRY_AUTH_TOKEN,
-  sourcemaps: { disable: !process.env.SENTRY_AUTH_TOKEN },
-  // Don't auto-instrument the Clerk middleware — it runs in Edge Runtime
-  // and Sentry's instrumentation can crash there without a configured DSN.
-  autoInstrumentMiddleware: false,
-});
+export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,12 +6,9 @@ const nextConfig: NextConfig = {
 };
 
 export default withSentryConfig(nextConfig, {
-  // Suppress Sentry source-map upload warnings during build when DSN is not set.
   silent: !process.env.SENTRY_AUTH_TOKEN,
-  // Disable automatic instrumentation tree-shaking warnings in development.
-  disableLogger: true,
-  // Upload source maps only when a Sentry auth token is present (CI/production).
-  sourcemaps: {
-    disable: !process.env.SENTRY_AUTH_TOKEN,
-  },
+  sourcemaps: { disable: !process.env.SENTRY_AUTH_TOKEN },
+  // Don't auto-instrument the Clerk middleware — it runs in Edge Runtime
+  // and Sentry's instrumentation can crash there without a configured DSN.
+  autoInstrumentMiddleware: false,
 });

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,7 +1,9 @@
 import * as Sentry from "@sentry/nextjs";
 
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  tracesSampleRate: 0.1,
-  debug: false,
-});
+if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
+  Sentry.init({
+    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+    tracesSampleRate: 0.1,
+    debug: false,
+  });
+}


### PR DESCRIPTION
## What

Fixes three bugs found during manual testing on the dev branch.

## Changes

### React error #31 — Date objects in Deadlines + Timeline tabs
Postgres `DATE`/`TIMESTAMPTZ` columns return `Date` objects. Three places cast directly with `as string` instead of converting:
- `entry.date` in Timeline
- `d.date` in active deadlines
- `d.date` in completed deadlines

Fixed by routing all through `fmtDate()`.

### Resend build failure
`new Resend(apiKey)` at module level throws at Next.js build time when `RESEND_API_KEY` is absent (preview deployments). Moved instantiation inside the function with an early return guard. Fixed in both `lib/email.ts` and `cron/deadlines/route.ts`. Also updated from-address to `support@veracase.app`.

### Sentry middleware 500
`withSentryConfig` in `next.config.ts` auto-instruments the Clerk middleware in Edge Runtime. Without `NEXT_PUBLIC_SENTRY_DSN` set, Sentry crashes on every request. Removed `withSentryConfig` wrapper — the `sentry.*.config.ts` init files remain with DSN guards and activate automatically when the DSN is configured.

### SEO public routes
Added `/pricing`, `/privacy`, `/terms`, `/sitemap.xml`, `/robots.txt`, `/opengraph-image`, `/twitter-image` to Clerk middleware public routes so crawlers and link previews can access them unauthenticated.

## Test
- Deadlines tab: add a deadline, confirm dates render correctly (no React crash)
- Build passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)